### PR TITLE
fix: repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Traits and auto-implementations to improve arithmetic operations 
 keywords = ["option", "arithmetic", "operations", "ord", "cmp"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/fengalin/opt-operations"
+repository = "https://github.com/fengalin/option-operations"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
The link points to a non existing repository.